### PR TITLE
Replace Eigen::Matrix3X<double>

### DIFF
--- a/C++/scope/utils/Setup.cpp
+++ b/C++/scope/utils/Setup.cpp
@@ -192,7 +192,7 @@ int loadKeyPoint2DMeasurements(const std::string &file,
     exit(-1);
   }
 
-  Measurements = Eigen::Map<Eigen::Matrix3X<double>>(
+  Measurements = Eigen::Map<Eigen::Matrix<double, 3, Eigen::Dynamic>>(
                      measurements.data<double>(), measurements.shape[1],
                      measurements.shape[0])
                      .cast<Scalar>();
@@ -213,7 +213,7 @@ int loadKeyPoint3DMeasurements(const std::string &file,
     exit(-1);
   }
 
-  Measurements = Eigen::Map<Eigen::Matrix3X<double>>(
+  Measurements = Eigen::Map<Eigen::Matrix<double, 3, Eigen::Dynamic>>(
                      measurements.data<double>(), measurements.shape[1],
                      measurements.shape[0])
                      .cast<Scalar>();


### PR DESCRIPTION
Hi Taosha,

In "C++/scope/utils/Setup.cpp", there are two places with "Eigen::Matrix3X<double>", which seem to cause compilation error: "error: ‘Matrix3X’ is not a member of ‘Eigen’;". I fixed that by replacing them with "Eigen::Matrix<double, 3, Eigen::Dynamic>". Would you consider updating them in the repo?

Thank you!
Muchen